### PR TITLE
adds ternary to remove invalid StyleSheet properties in non-web envs.

### DIFF
--- a/src/components/ResponderView.tsx
+++ b/src/components/ResponderView.tsx
@@ -30,11 +30,13 @@ const styleSheet = RN.StyleSheet.create({
     flexShrink: 1,
     flexBasis: 'auto',
     alignItems: 'center',
-    cursor: 'pointer',
-    // This is for web
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    userSelect: 'none'
+    ...(RN.Platform.OS === 'web' ? {
+      cursor: 'pointer',
+      // This is for web
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      userSelect: 'none'
+    } : {})
   },
   row: {
     flexDirection: 'row'

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -19,7 +19,7 @@ function getTrackStyle (length: number, thickness: number, color: RN.ColorValue,
       // This is for web
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      userSelect: 'none',
+      ...(RN.Platform.OS === 'web' ? { userSelect: 'none' } : {}),
       [vertical ? 'width' : 'height']: thickness
     }
   }).thumb


### PR DESCRIPTION
Fix #41 

Just a simple ternary to web-only properties only in web environments.