### PR TITLE
fix rtl issue

### DIFF
--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -100,15 +100,18 @@ const Slider = React.forwardRef<RN.View, SliderProps>((props: SliderProps, forwa
 
   const { marks, onLayoutUpdateMarks } = useCustomMarks(CustomMark, { step, minimumValue, maximumValue, activeValues: [value], inverted, vertical })
 
+  const minimumTrackLength = inverted? (1 - percentage) * 100: percentage * 100
+  const maximumTrackLength = inverted? percentage * 100 : (1 - percentage) * 100
+
   return (
     <RN.View {...others}>
       <ResponderView style={styleSheet[vertical ? 'vertical' : 'horizontal']} ref={forwardedRef} maximumValue={maximumValue} minimumValue={minimumValue} step={step}
         value={value} updateValue={updateValue} onPress={onPress} onMove={onMove} onRelease={onRelease}
         enabled={enabled} vertical={vertical} inverted={inverted} onLayout={onLayoutUpdateMarks}
       >
-        <Track color={minimumTrackTintColor} style={minStyle} length={percentage * 100} vertical={vertical} thickness={trackHeight} />
+        <Track color={minimumTrackTintColor} style={minStyle} length={minimumTrackLength} vertical={vertical} thickness={trackHeight} />
         <Thumb {...thumbProps} value={value} />
-        <Track color={maximumTrackTintColor} style={maxStyle} length={(1 - percentage) * 100} vertical={vertical} thickness={trackHeight} />
+        <Track color={maximumTrackTintColor} style={maxStyle} length={maximumTrackLength} vertical={vertical} thickness={trackHeight} />
         {marks}
       </ResponderView>
     </RN.View>


### PR DESCRIPTION
Thanks for the package. I identified a bug related to the `inverted` feature. While the `inverted` prop is being handled correctly by `eventToValue` helper function and it correctly maps `x` & `y` event coordinates to the slider value to be selected, the same does not happen when calculating the tracks lengths. 

Here is a video demonstrating what happens when the app is in `RTL` mode and `inverted` prop is set to `true`.

https://github.com/Sharcoux/slider/assets/27894818/b01cd588-3e9d-44f0-b027-fbe491c7161a

This PR takes `inverted` prop into consideration when calculating the tracks lengths.