### PR TITLE
Fixes Range Slider Thumb issue

### DIFF
--- a/src/hooks/useRange.ts
+++ b/src/hooks/useRange.ts
@@ -34,7 +34,7 @@ const useRange = ({ step, range: propValue, minimumRange, minimumValue, maximumV
 
   // Max value thumb
   const { updateValue: updateMaxValue, canMove: canMoveMax, value: maxValue } = useThumb({
-    minimumValue: Math.min(maximumValue, minRef.current + minimumRange),
+    minimumValue: Math.min(maximumValue, minProp + minimumRange),
     maximumValue,
     value: maxProp,
     step,


### PR DESCRIPTION
Fixes #110 

Issue: Ref does not trigger primitive value change event, so when both thumbs are changed min-thumb updates to zero while max-thumb calculates its minimum value from old min-thumb value instead of newly changed one.