### PR TITLE
fix: trigger `onSlidingComplete` when touch is terminated (e.g. by a possible `ScrollView`)

### DIFF
--- a/src/components/ResponderView.tsx
+++ b/src/components/ResponderView.tsx
@@ -130,6 +130,7 @@ const ResponderView = React.forwardRef<RN.View, Props>((props, ref) => {
       onResponderRelease={onRelease}
       onResponderMove={onMove}
       onResponderTerminationRequest={keepResponder}
+      onResponderTerminate={onRelease}
     >
       <SliderView
         vertical={vertical}


### PR DESCRIPTION
Hi, first of all thanks for maintaining this awesome package!
Since I found a (minor) issue when placing the slider inside a `<ScrollView>` and found the problem, I wanted to contribute here.

**Current behaviour:**
If I scroll to terminate the responder and I re-tap on the slider, no matter where I put my finger, it will always start/resume from the previous thumb.

**Expected behaviour:**
If I scroll to terminate the responder and I re-tap on the slider, I expect it will correctly pick the right thumb based on where I tap.

In order to fix this issue, this PR will trigger `onRelease` (so also `onSlidingComplete`) in `onResponderTerminate` callback, which is called when the `RangeSlider` is placed inside a `<ScrollView>`.
In this way, we ensure that `onSlidingComplete` is always triggered.

Hopefully this will be a useful fix, though it's a tiny simple change!

---

Here are some videos to easily understand the difference:

#### Before
https://github.com/user-attachments/assets/67b7bf01-f1f9-48d5-b738-e176e6a038c1

#### After
https://github.com/user-attachments/assets/edc17df9-8558-4ea4-89b8-5b0dbce211f0
